### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/org/kercheval/gradle/vcs/VCSAccessFactory.java
+++ b/src/main/java/org/kercheval/gradle/vcs/VCSAccessFactory.java
@@ -15,6 +15,8 @@ import org.kercheval.gradle.vcs.none.VCSNoneImpl;
 //
 public class VCSAccessFactory
 {
+    private VCSAccessFactory() {}
+    
 	public static VCSAccess getCurrentVCS(final String type, final File srcRootDir,
 		final Logger logger)
 	{


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed