### PR TITLE
Code quality fix - Case insensitive string comparisons should be made without intermediate upper or lower casing.

### DIFF
--- a/src/main/java/org/kercheval/gradle/buildrelease/BuildReleasePlugin.java
+++ b/src/main/java/org/kercheval/gradle/buildrelease/BuildReleasePlugin.java
@@ -94,8 +94,7 @@ public class BuildReleasePlugin implements Plugin<Project> {
             //
             // We cannot tag and push when we have no VCS. Silently fail...
             //
-            if (!VCSAccess.Type.NONE.toString().toLowerCase()
-                .equals(vcsTask.getType().toLowerCase())) {
+            if (!VCSAccess.Type.NONE.toString().equalsIgnoreCase(vcsTask.getType())) {
                 final VCSTaskUtil vcsUtil = new VCSTaskUtil(project);
 
                 //

--- a/src/main/java/org/kercheval/gradle/buildvcs/BuildVCSTask.java
+++ b/src/main/java/org/kercheval/gradle/buildvcs/BuildVCSTask.java
@@ -103,7 +103,7 @@ public class BuildVCSTask
 		boolean foundType = false;
 		for (final VCSAccess.Type iterType : VCSAccess.Type.values())
 		{
-			if (desiredType.equals(iterType.toString().toLowerCase()))
+			if (desiredType.equalsIgnoreCase(iterType.toString()))
 			{
 				foundType = true;
 			}

--- a/src/main/java/org/kercheval/gradle/vcs/VCSAccessFactory.java
+++ b/src/main/java/org/kercheval/gradle/vcs/VCSAccessFactory.java
@@ -20,7 +20,7 @@ public class VCSAccessFactory
 	{
 		final VCSAccess rVal = new VCSNoneImpl(srcRootDir, logger);
 		final String desiredType = type.toLowerCase();
-		if (desiredType.equals(VCSAccess.Type.GIT.toString().toLowerCase()))
+		if (desiredType.equalsIgnoreCase(VCSAccess.Type.GIT.toString()))
 		{
 			return new VCSGitImpl(srcRootDir, logger);
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1157

Please let me know if you have any questions.

Faisal Hameed