### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/src/main/java/org/kercheval/gradle/buildrelease/BuildReleasePlugin.java
+++ b/src/main/java/org/kercheval/gradle/buildrelease/BuildReleasePlugin.java
@@ -59,7 +59,7 @@ public class BuildReleasePlugin implements Plugin<Project> {
                     final AbstractTask uploadTask = (AbstractTask) new GradleInfoSource(project)
                         .getTask(buildInitTask.getUploadtask());
 
-                    if ((null == uploadTask)) {
+                    if (null == uploadTask) {
                         project.getLogger().debug("The upload task '"
                                 + buildInitTask.getUploadtask()
                                 + "' specified for buildreleaseupdate does not exist.  This task may be dynamic.");

--- a/src/main/java/org/kercheval/gradle/info/TeamCityInfoSource.java
+++ b/src/main/java/org/kercheval/gradle/info/TeamCityInfoSource.java
@@ -40,6 +40,6 @@ public class TeamCityInfoSource
 	@Override
 	public boolean isActive()
 	{
-		return (null != System.getenv("TEAMCITY_VERSION"));
+		return null != System.getenv("TEAMCITY_VERSION");
 	}
 }

--- a/src/main/java/org/kercheval/gradle/vcs/VCSStatus.java
+++ b/src/main/java/org/kercheval/gradle/vcs/VCSStatus.java
@@ -90,9 +90,9 @@ public class VCSStatus
 
 	public boolean isClean()
 	{
-		return (getAdded().isEmpty() && getChanged().isEmpty() && getConflicting().isEmpty()
+		return getAdded().isEmpty() && getChanged().isEmpty() && getConflicting().isEmpty()
 			&& getMissing().isEmpty() && getModified().isEmpty() && getRemoved().isEmpty() && getUntracked()
-			.isEmpty());
+			.isEmpty();
 	}
 
 	public void setAdded(final Set<String> added)

--- a/src/main/java/org/kercheval/gradle/vcs/git/VCSGitImpl.java
+++ b/src/main/java/org/kercheval/gradle/vcs/git/VCSGitImpl.java
@@ -420,10 +420,7 @@ public class VCSGitImpl
 					}
 					finally
 					{
-						if (null != revWalk)
-						{
-							revWalk.dispose();
-						}
+					    revWalk.dispose();
 					}
 				}
 			}

--- a/src/test/java/org/kercheval/gradle/buildversion/BuildVersionTaskTest.java
+++ b/src/test/java/org/kercheval/gradle/buildversion/BuildVersionTaskTest.java
@@ -130,7 +130,7 @@ public class BuildVersionTaskTest
 	private void validateVersionTag(final JGitTestRepository repoUtil, final Project project)
 		throws VCSException
 	{
-		final BuildVersion version = ((BuildVersion) project.getVersion());
+		final BuildVersion version = (BuildVersion) project.getVersion();
 		final VCSInfoSource git = new VCSGitImpl(repoUtil.getOriginFile(), project.getLogger());
 		final List<VCSTag> tagList = git.getTags(version.getValidatePattern());
 		boolean found = false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2583

Please let me know if you have any questions.

Faisal Hameed