### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/src/main/java/org/kercheval/gradle/buildinfo/BuildInfoTask.java
+++ b/src/main/java/org/kercheval/gradle/buildinfo/BuildInfoTask.java
@@ -162,9 +162,9 @@ public class BuildInfoTask
 							tasknameMap.put(task.getName(), task);
 						}
 
-						for (final String taskname : taskmap.keySet())
+						for (final Entry<String, String> taskInfo : taskmap.entrySet())
 						{
-							final Task task = tasknameMap.get(taskname);
+							final Task task = tasknameMap.get(taskInfo.getKey());
 
 							if (null != task)
 							{
@@ -200,7 +200,7 @@ public class BuildInfoTask
 												// add in the from and include parameters for
 												// the child spec
 												//
-												copySpec.into(taskmap.get(taskname)).include(
+												copySpec.into(taskInfo.getValue()).include(
 													getFilename());
 
 												return copySpec;
@@ -228,7 +228,7 @@ public class BuildInfoTask
 									//
 									project.getLogger().info(
 										"buildinfo: task defined in taskmap does not exist: "
-											+ taskname);
+											+ taskInfo.getKey());
 								}
 							}
 						}
@@ -326,8 +326,7 @@ public class BuildInfoTask
 
 				for (final Entry<String, Object> entry : getCustominfo().entrySet())
 				{
-					customProps.put("custom.info." + entry.getKey().toString(), entry.getValue()
-						.toString());
+					customProps.put("custom.info." + entry.getKey(), entry.getValue().toString());
 				}
 
 				customProps.store(out, "Custom build info specified in gradle build file");

--- a/src/main/java/org/kercheval/gradle/console/TextDevices.java
+++ b/src/main/java/org/kercheval/gradle/console/TextDevices.java
@@ -26,7 +26,7 @@ import java.io.PrintWriter;
  */
 public final class TextDevices
 {
-	private static TextDevice DEFAULT = (System.console() == null) ? streamDevice(System.in,
+	private static final TextDevice DEFAULT = (System.console() == null) ? streamDevice(System.in,
 		System.out) : new ConsoleDevice(System.console());
 
 	/**

--- a/src/main/java/org/kercheval/gradle/vcs/git/VCSGitImpl.java
+++ b/src/main/java/org/kercheval/gradle/vcs/git/VCSGitImpl.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.MergeCommand.FastForwardMode;
@@ -395,11 +396,11 @@ public class VCSGitImpl
 
 			final Map<String, Ref> tags = repository.getTags();
 
-			for (final String name : tags.keySet())
+			for (final Entry<String, Ref> tag : tags.entrySet())
 			{
-				if (name.matches(regexFilter))
+				if (tag.getKey().matches(regexFilter))
 				{
-					final Ref ref = tags.get(name);
+					final Ref ref = tag.getValue();
 					final RevWalk revWalk = new RevWalk(repository);
 
 					try

--- a/src/test/java/org/kercheval/gradle/buildinfo/BuildInfoPluginTest.java
+++ b/src/test/java/org/kercheval/gradle/buildinfo/BuildInfoPluginTest.java
@@ -27,9 +27,8 @@ public class BuildInfoPluginTest {
             tasknameMap.put(task.getName(), task);
         }
 
-        final BuildInfoTask task = (BuildInfoTask) tasknameMap.get(BuildInfoPlugin.INFO_TASK_NAME);
+        return (BuildInfoTask) tasknameMap.get(BuildInfoPlugin.INFO_TASK_NAME);
 
-        return task;
     }
 
     private void resetDefaultTaskValues(final Project project, final BuildInfoTask task)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S1858 -  "toString()" should never be called on a String object.
squid:S3008 -  Static non-final field names should comply with a naming convention.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1858
https://dev.eclipse.org/sonar/rules/show/squid:S3008
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.

Faisal Hameed