### PR TITLE
Move to a newer version of jgit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,7 @@ buildversion {
 		// values.  Release gets the default pattern of the maven default
 		//
 		def branchName = buildvcs.getBranchName()
-        if (branchName != 'release' &&
-            !project.hasProperty('noSnapshot')) {
+		if (branchName != 'release' && !project.hasProperty('noSnapshot')) {
 			version.setPattern("%M%.%m%-SNAPSHOT")
 		}
 		version.updateMajor(new Integer(buildMajorVersion))
@@ -41,18 +40,18 @@ clean {
 // Manifest specific properties.
 //
 tasks.withType(Jar) {
-    manifest {
+	manifest {
 		doFirst {
 			attributes 'Implementation-Title': description, 'Implementation-Version': version
 		}
-    }
+	}
 }
 
 //
 // Enable lint compilation
 //
 tasks.withType(JavaCompile) {
-    options.compilerArgs << "-Xlint:unchecked"
+	options.compilerArgs << "-Xlint:unchecked"
 }
 
 //
@@ -64,7 +63,7 @@ repositories {
 
 dependencies {
 	compile gradleApi()
-    compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '2.3.1.201302201838-r'
+	compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '4.10.0.201712302008-r'
 	testCompile group: 'junit', name: 'junit', version: '4.+'
 }
 


### PR DESCRIPTION
This is to get a newer version of jsch (a transitive dependency of
jgit).  Older versions of jsch don't appear to support the key exchange
algorithms required by github.  This means that when this plugin tries
to push tags to a github repo it will fail with the error `Algorithm
negotiation fail`.